### PR TITLE
Improve cluster state fetch and checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 Changes
 =======
 
+1.7.0 (2021-12-15)
+------------------
+
+* add `execute_timeout` for `Manager`
+* improve cluster state reload logging
+* reduce number of addresses to fetch cluster state
+* acquire dedicate connection from pool to fetch cluster state
+* extend ClusterState by new attributes: `state`, `state_from`, `current_epoch`
+
 1.6.1 (2021-11-23)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ source = aioredis_cluster,tests/unit_tests
 
 [flake8]
 max_line_length = 100
-extend_ignore = W606, E203
+extend_ignore = W606, E203, E741
 
 [mypy]
 ignore_missing_imports = True

--- a/src/aioredis_cluster/abc.py
+++ b/src/aioredis_cluster/abc.py
@@ -1,8 +1,9 @@
 from abc import abstractmethod
-from typing import AnyStr, List, Sequence, Union
+from typing import AnyStr, AsyncContextManager, List, Sequence, Union
 
 from aioredis import Redis
-from aioredis.abc import AbcChannel, AbcConnection, AbcPool
+from aioredis.abc import AbcChannel, AbcConnection
+from aioredis.abc import AbcPool as _AbcPool
 
 from aioredis_cluster.cluster_state import ClusterState
 from aioredis_cluster.structs import Address, ClusterNode
@@ -52,4 +53,30 @@ class AbcCluster(AbcConnection):
 
     @abstractmethod
     def extract_keys(self, command_seq: Sequence[BytesOrStr]) -> List[bytes]:
+        pass
+
+
+class AbcPool(_AbcPool):
+    @abstractmethod
+    def get(self) -> AsyncContextManager[Redis]:
+        pass
+
+    @property
+    @abstractmethod
+    def size(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def minsize(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def maxsize(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def freesize(self) -> int:
         pass

--- a/src/aioredis_cluster/cluster.py
+++ b/src/aioredis_cluster/cluster.py
@@ -3,7 +3,17 @@ import logging
 from collections import ChainMap
 from time import monotonic
 from types import MappingProxyType
-from typing import Any, AnyStr, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Any,
+    AnyStr,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+)
 
 from aioredis import Redis, create_pool
 from aioredis.errors import ProtocolError, ReplyError
@@ -89,7 +99,7 @@ class Cluster(AbcCluster):
         pool_maxsize: int = None,
         commands_factory: CommandsFactory = None,
         connect_timeout: float = None,
-        pool_cls: AbcPool = None,
+        pool_cls: Type[AbcPool] = None,
     ) -> None:
         if len(startup_nodes) < 1:
             raise ValueError("startup_nodes must be one at least")
@@ -166,6 +176,7 @@ class Cluster(AbcCluster):
             self._pooler,
             state_reload_interval=state_reload_interval,
             follow_cluster=follow_cluster,
+            execute_timeout=self._attempt_timeout,
         )
 
         self._loop = asyncio.get_event_loop()

--- a/src/aioredis_cluster/commands/commands.py
+++ b/src/aioredis_cluster/commands/commands.py
@@ -4,6 +4,7 @@ from typing import AnyStr, Callable, List, Optional, Set, Type, TypeVar, cast
 
 from aioredis.abc import AbcConnection
 from aioredis.commands import Redis
+from aioredis.util import _NOTSET
 
 from aioredis_cluster.abc import AbcCluster
 
@@ -52,7 +53,7 @@ class RedisCluster(ClusterCommandsMixin, Redis):
         return await self.connection.keys_master(key, *keys)
 
     # special behavior for commands
-    async def randomkey(self) -> Optional[bytes]:
+    async def randomkey(self, *, encoding=_NOTSET) -> Optional[bytes]:
         if not conn_is_cluster(self.connection):
             return await super().randomkey()
 

--- a/src/aioredis_cluster/connection.py
+++ b/src/aioredis_cluster/connection.py
@@ -2,6 +2,7 @@ import asyncio
 
 import aioredis
 
+from aioredis_cluster.abc import AbcPool
 from aioredis_cluster.errors import ConnectTimeoutError
 
 
@@ -10,7 +11,7 @@ __all__ = [
 ]
 
 
-class ConnectionsPool(aioredis.ConnectionsPool):
+class ConnectionsPool(aioredis.ConnectionsPool, AbcPool):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 

--- a/src/aioredis_cluster/typedef.py
+++ b/src/aioredis_cluster/typedef.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable, List, Tuple, TypeVar, Union
+from typing import Awaitable, Callable, Tuple, TypeVar, Union
 
 from aioredis.commands import Redis
 
@@ -9,7 +9,6 @@ TRedis = TypeVar("TRedis", bound=Redis)
 
 BytesOrStr = Union[bytes, str]
 AioredisAddress = Union[str, Tuple[str, int]]
-SlotsResponse = List[List]
 CommandsFactory = Callable[[AbcConnection], TRedis]
 PoolerBatchCallback = Callable[[AbcPool], Awaitable[None]]
 PoolCreator = Callable[[AioredisAddress], Awaitable[AbcPool]]

--- a/src/aioredis_cluster/util.py
+++ b/src/aioredis_cluster/util.py
@@ -16,7 +16,7 @@ from typing import (
 from aioredis.util import _converters, decode
 
 
-__all__ = [
+__all__ = (
     "ensure_bytes",
     "iter_ensure_bytes",
     "ensure_str",
@@ -29,7 +29,7 @@ __all__ = [
     "parse_moved_response_error",
     "retry_backoff",
     "unused_port",
-]
+)
 
 _T = TypeVar("_T")
 

--- a/tests/unit_tests/aioredis_cluster/manager/test_cluster_state.py
+++ b/tests/unit_tests/aioredis_cluster/manager/test_cluster_state.py
@@ -1,3 +1,4 @@
+import datetime
 from functools import lru_cache
 
 import pytest
@@ -5,6 +6,7 @@ import pytest
 from aioredis_cluster.errors import ClusterStateError, UncoveredSlotError
 from aioredis_cluster.manager import (
     ClusterState,
+    NodeClusterState,
     _ClusterStateData,
     create_cluster_state,
 )
@@ -15,7 +17,14 @@ from ._cluster_slots import SLOTS
 
 @lru_cache(None)
 def get_state():
-    return create_cluster_state(SLOTS)
+    return create_cluster_state(
+        SLOTS,
+        {
+            "cluster_state": "ok",
+            "cluster_current_epoch": "1",
+        },
+        Address("172.17.0.1", 6379),
+    )
 
 
 def get_nodes_addr(nodes):
@@ -35,7 +44,14 @@ def get_slots_ranges(slots):
 
 
 def test_create_cluster_state():
-    state = create_cluster_state(SLOTS)
+    state = create_cluster_state(
+        SLOTS,
+        {
+            "cluster_state": "ok",
+            "cluster_current_epoch": "1",
+        },
+        Address("172.17.0.1", 6379),
+    )
 
     addrs = sorted([Address("172.17.0.2", port) for port in range(7000, 7005)])
     masters_addrs = sorted(
@@ -76,6 +92,11 @@ def test_create_cluster_state():
     assert get_nodes_addr(state_data.masters) == masters_addrs
     assert get_nodes_addr([r for rs in state_data.replicas.values() for r in rs]) == replicas_addrs
     assert get_slots_ranges(state_data.slots) == slot_ranges
+    assert state.state is NodeClusterState.OK
+    assert state.state_from == Address("172.17.0.1", 6379)
+    assert isinstance(state._data.created_at, datetime.datetime)
+    assert state._data.created_at_local > 0
+    assert state.current_epoch == 1
 
     state.repr_stats()
     str(state)
@@ -174,3 +195,28 @@ def test_random_node(mocker):
     result = state.random_node()
 
     assert result is state._data.nodes[state._data.addrs[1]]
+
+
+def test_state__with_fail_state():
+    state = create_cluster_state(
+        SLOTS,
+        {
+            "cluster_state": "fail",
+            "cluster_current_epoch": "1",
+        },
+        Address("172.17.0.1", 6379),
+    )
+
+    assert state.state is NodeClusterState.FAIL
+
+    state = create_cluster_state(
+        SLOTS,
+        {
+            "cluster_state": "foobar",
+            "cluster_current_epoch": "1",
+        },
+        Address("172.17.0.1", 6379),
+    )
+
+    assert state.state is NodeClusterState.UNKNOWN
+    assert state.current_epoch == 1

--- a/tests/unit_tests/aioredis_cluster/manager/test_manager.py
+++ b/tests/unit_tests/aioredis_cluster/manager/test_manager.py
@@ -4,18 +4,36 @@ import time
 import mock
 import pytest
 
+from aioredis_cluster.cluster_state import ClusterState, NodeClusterState
 from aioredis_cluster.manager import ClusterManager
 from aioredis_cluster.structs import Address, ClusterNode
+
+from ._cluster_slots import SLOTS
 
 
 @pytest.fixture
 def pooler_mock():
     def factory():
-        mocked_pool = mock.NonCallableMock()
-        mocked_pool.execute = mock.AsyncMock()
+        conn = mock.NonCallableMock()
+        conn.execute = mock.AsyncMock(
+            return_value=object(),
+        )
+        pool = mock.NonCallableMock()
+        pool.execute = mock.AsyncMock(
+            return_value=object(),
+        )
+
+        acquirer_mock = mock.NonCallableMock()
+        acquirer_mock.__aenter__ = mock.AsyncMock(return_value=conn)
+        acquirer_mock.__aexit__ = mock.AsyncMock(return_value=None)
+        pool.get.return_value = acquirer_mock
 
         mocked = mock.NonCallableMock()
-        mocked.ensure_pool = mock.AsyncMock(return_value=mocked_pool)
+        mocked.ensure_pool = mock.AsyncMock(return_value=pool)
+
+        mocked._pool = pool
+        mocked._conn = conn
+
         return mocked
 
     return factory
@@ -113,9 +131,7 @@ async def test_load_state(mocker, pooler_mock):
 
     manager = ClusterManager(["addr1", "addr2"], pooler)
 
-    mocked_load_slots = mocker.patch.object(manager, "_load_slots", new=mock.AsyncMock())
-    mocked_create_cluster_state = mocker.patch(manager.__module__ + ".create_cluster_state")
-    mocked_state = mocked_create_cluster_state.return_value
+    mocked_state = mock.NonCallableMock()
     mocked_state._data.masters = [
         ClusterNode(Address("master1", 6666), "master1_id"),
         ClusterNode(Address("master2", 7777), "master2_id"),
@@ -123,6 +139,13 @@ async def test_load_state(mocker, pooler_mock):
     mocked_state._data.addrs = [object(), object()]
     mocked_state.random_master.return_value = ClusterNode(
         Address("random_master", 5555), "random_master_id"
+    )
+    mocked_fetch_state = mocker.patch.object(
+        manager,
+        "_fetch_state",
+        new=mock.AsyncMock(
+            return_value=mocked_state,
+        ),
     )
 
     mocked_create_registry = mocker.patch(manager.__module__ + ".create_registry")
@@ -132,7 +155,7 @@ async def test_load_state(mocker, pooler_mock):
     assert result is mocked_state
     assert result is manager._state
     assert manager._commands is mocked_create_registry.return_value
-    mocked_load_slots.assert_called_once_with(["addr1", "addr2"])
+    mocked_fetch_state.assert_called_once_with(["addr1", "addr2"])
     mocked_create_registry.assert_called_once_with(
         pooler.ensure_pool.return_value.execute.return_value
     )
@@ -159,21 +182,46 @@ async def test_init(mocker, pooler_mock):
     await manager.close()
 
 
-async def test_load_slots__first_response(pooler_mock):
+async def test_fetch_state__first_response(pooler_mock, mocker):
     pooler = pooler_mock()
-    pool = pooler.ensure_pool.return_value
+    pool = pooler._pool
+    conn = pooler._conn
+    cluster_slots_resp = object()
+    conn.execute.side_effect = [
+        "cluster_state:ok\ncluster_current_epoch:1",
+        cluster_slots_resp,
+    ]
     manager = ClusterManager(["addr1"], pooler)
+    mocked_create_cluster_state = mocker.patch(ClusterManager.__module__ + ".create_cluster_state")
 
-    result = await manager._load_slots(["addr2", "addr3"])
+    result = await manager._fetch_state(["addr2", "addr3"])
 
-    assert result is pool.execute.return_value
+    assert result is mocked_create_cluster_state.return_value
     pooler.ensure_pool.assert_called_once_with("addr2")
-    pool.execute.assert_called_once_with(b"CLUSTER", b"SLOTS", encoding="utf-8")
+    pool.get.asssert_called_once()
+    assert conn.execute.await_count == 2
+    execute_calls = conn.execute.call_args_list
+    assert execute_calls[0] == mock.call(b"CLUSTER", b"INFO", encoding="utf-8")
+    assert execute_calls[1] == mock.call(b"CLUSTER", b"SLOTS", encoding="utf-8")
 
 
-async def test_load_slots__with_error_but_success(pooler_mock):
+async def test_fetch_state__with_fail_state(pooler_mock, mocker):
     pooler = pooler_mock()
-    pool = pooler.ensure_pool.return_value
+    conn = pooler._conn
+    conn.execute.side_effect = [
+        "cluster_state:fail\ncluster_current_epoch:1",
+        SLOTS,
+    ]
+    manager = ClusterManager(["addr1"], pooler)
+    result = await manager._fetch_state(["addr2"])
+
+    assert result.state is NodeClusterState.FAIL
+
+
+async def test_fetch_state__with_error_but_success(pooler_mock):
+    pooler = pooler_mock()
+    conn = pooler._conn
+    pool = pooler._pool
 
     def ensure_pool_se(addr):
         if addr == "addr1":
@@ -182,47 +230,68 @@ async def test_load_slots__with_error_but_success(pooler_mock):
 
     pooler.ensure_pool.side_effect = ensure_pool_se
 
-    def pool_execute_se(*args, **kwargs):
-        if pool.execute.call_count == 1:
-            raise RuntimeError("execute")
-        return pool.execute.return_value
-
-    pool.execute.side_effect = pool_execute_se
+    conn.execute.side_effect = [
+        # first try
+        "cluster_state:fail\ncluster_current_epoch:1",
+        object(),
+        # second try
+        "cluster_state:ok\ncluster_current_epoch:1",
+        RuntimeError("execute fail"),
+        # success third try
+        "cluster_state:ok\ncluster_current_epoch:1",
+        SLOTS,
+    ]
 
     manager = ClusterManager(["addr1"], pooler)
 
-    result = await manager._load_slots(["addr1", "addr2", "addr3"])
+    result = await manager._fetch_state(["addr1", "addr2", "addr3", "addr4"])
 
-    assert result is pool.execute.return_value
-    assert pooler.ensure_pool.call_count == 3
-    assert pool.execute.call_count == 2
+    assert isinstance(result, ClusterState)
+    assert result.state is NodeClusterState.OK
+    assert result.state_from == "addr4"
+    assert pooler.ensure_pool.await_count == 4
+    assert conn.execute.await_count == 6
     pooler.ensure_pool.assert_has_calls(
         [
             mock.call("addr1"),
             mock.call("addr2"),
             mock.call("addr3"),
+            mock.call("addr4"),
         ]
     )
-    pool.execute.assert_has_calls(
+    conn.execute.assert_has_calls(
         [
-            mock.call(b"CLUSTER", b"SLOTS", encoding="utf-8"),
+            mock.call(b"CLUSTER", b"INFO", encoding="utf-8"),
             mock.call(b"CLUSTER", b"SLOTS", encoding="utf-8"),
         ]
     )
 
 
-async def test_load_slots__with_error(pooler_mock):
+async def test_fetch_state__with_error(pooler_mock):
     pooler = pooler_mock()
+    pool = pooler._pool
+    conn = pooler._conn
 
-    def ensure_pool_se(addr):
-        raise RuntimeError(addr)
+    pooler.ensure_pool.side_effect = [
+        RuntimeError("first error"),
+        pool,
+        pool,
+        pool,
+    ]
 
-    pooler.ensure_pool.side_effect = ensure_pool_se
+    pool.get.return_value.__aenter__.side_effect = [
+        RuntimeError("second error"),
+        conn,
+        conn,
+    ]
+
+    execute_resp = mock.NonCallableMagicMock()
+    conn.execute.side_effect = [RuntimeError("third error"), execute_resp]
 
     manager = ClusterManager(["addr1"], pooler)
 
-    with pytest.raises(RuntimeError, match="addr1"):
-        await manager._load_slots(["addr1", "addr2", "addr3"])
+    with pytest.raises(RuntimeError, match="third error"):
+        await manager._fetch_state(["addr1", "addr2", "addr3"])
 
     assert pooler.ensure_pool.call_count == 3
     pooler.ensure_pool.assert_has_calls(

--- a/tests/unit_tests/aioredis_cluster/test_cluster.py
+++ b/tests/unit_tests/aioredis_cluster/test_cluster.py
@@ -98,6 +98,7 @@ async def test_init__defaults(mocker):
         cl._pooler,
         state_reload_interval=None,
         follow_cluster=None,
+        execute_timeout=5.0,
     )
 
 
@@ -145,6 +146,7 @@ async def test_init__customized(mocker):
         cl._pooler,
         state_reload_interval=kwargs["state_reload_interval"],
         follow_cluster=kwargs["follow_cluster"],
+        execute_timeout=kwargs["attempt_timeout"],
     )
 
 


### PR DESCRIPTION
* add `execute_timeout` for `Manager`
* improve cluster state reload logging
* reduce number of addresses to fetch cluster state
* acquire dedicate connection from pool to fetch cluster state
* extend ClusterState by new attributes: `state`, `state_from`, `current_epoch`